### PR TITLE
Adds PMD for APEX code scanning workflow

### DIFF
--- a/.github/workflows/pmd-apex.yml
+++ b/.github/workflows/pmd-apex.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: pmd-apex
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '18 15 * * 2'
+
+permissions:
+  contents: read
+
+jobs:
+  pmd-code-scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Run PMD
+        id: pmd
+        uses: pmd/pmd-github-action@d57c0463ebba262a33d1983a5c6ac6031bfde43b
+        with:
+          rulesets: 'rulesets/apex/quickstart.xml'
+          sourcePath: 'force-app/main/default'
+          analyzeModifiedFilesOnly: false
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: pmd-report.sarif


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow file named `pmd-apex.yml` that runs PMD on Apex code in the `force-app/main/default` directory and uploads the results in SARIF format to the pull request or main branch. The workflow runs on a schedule and on push or pull request to the main branch.

Main workflow changes:

* <a href="diffhunk://#diff-c26848e9055dd48bc7cdc67d2b71c7842ca8b75f6fb0af781d4d978b328a6834R1-R43">`.github/workflows/pmd-apex.yml`</a>: Added a new GitHub Actions workflow file named `pmd-apex.yml` that runs PMD on Apex code in the `force-app/main/default` directory and uploads the results in SARIF format to the pull request or main branch.


Alerts: https://github.com/octodemo/advanced-security-apex/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3APMD

![image](https://github.com/octodemo/advanced-security-apex/assets/1760475/bde45a6b-4a5a-422b-bd41-96d32c264641)
